### PR TITLE
Update signing key for packages of Garuda Linux

### DIFF
--- a/garuda.prepare
+++ b/garuda.prepare
@@ -4,7 +4,7 @@ sed -i 's/#Server/Server/' /etc/pacman.d/mirrorlist
 # Enable multilib
 sed -i 's/#\[multilib\]/[multilib]/g' /etc/pacman.conf && sed -i '/\[multilib\]/!b;n;cInclude = /etc/pacman.d/mirrorlist' /etc/pacman.conf
 # Initialize Garuda Linux/BlackArch Keyring
-pacman-key --init && pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com && pacman-key --lsign-key 3056513887B78AEB && pacman --noconfirm -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-'{keyring,mirrorlist}'.pkg.tar.zst'
+pacman-key --init && pacman-key --recv-key FBA220DFC880C036 --keyserver keyserver.ubuntu.com && pacman-key --lsign-key FBA220DFC880C036 && pacman --noconfirm -U 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-'{keyring,mirrorlist}'.pkg.tar.zst'
 
 SHA512SUM='c8c787cf013ebd74ed036d365f5ca81a60132620e169ca05bbf82930cd8444cb554aaec17fdb9d107b024d2d54ab7c00c398de9f63009beffdd69675a5954f37'
 curl -O https://blackarch.org/strap.sh && echo $SHA512SUM" strap.sh" | sha512sum -c - && bash strap.sh && rm strap.sh


### PR DESCRIPTION
Chaotic keyring & mirrorlist are now signed with my key, which means we need to fetch it instead to successfully install Chaotic-AUR.