### PR TITLE
Fix tools tree setup

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: systemd/mkosi@62c050a4d0b60ba906428561e72b08efe99857a9
 
       - name: Setup mkosi tools tree
-        run: mkosi --distribution fedora --include=mkosi-tools
+        run: mkosi --distribution=fedora --include=mkosi-tools -C ""
 
       - name: Build the images
         run: ./check-all.py


### PR DESCRIPTION
It previously pulled in our normal configs setting `Format=disk` and enabling `Bootable=yes`. This leads to build failures as [`bootctl` is not found](https://github.com/nspawn/mkosi-definitions/actions/runs/15082567206).